### PR TITLE
Use DeferredUpdates for sending to webhooks

### DIFF
--- a/includes/DiscordNotifier.php
+++ b/includes/DiscordNotifier.php
@@ -162,7 +162,7 @@ class DiscordNotifier {
 
 		$post = $embed->build();
 
-		DeferredUpdates::addCallableUpdate( function() use ( $post, $webhook ) {
+		DeferredUpdates::addCallableUpdate( function () use ( $post, $webhook ) {
 			// Use file_get_contents to send the data. Note that you will need to have allow_url_fopen enabled in php.ini for this to work.
 			if ( $this->options->get( 'DiscordSendMethod' ) == 'file_get_contents' ) {
 				$this->sendHttpRequest( $webhook ?? $this->options->get( 'DiscordIncomingWebhookUrl' ), $post );

--- a/includes/DiscordNotifier.php
+++ b/includes/DiscordNotifier.php
@@ -165,7 +165,7 @@ class DiscordNotifier {
 		DeferredUpdates::addCallableUpdate( function () use ( $post, $webhook ) {
 			// Use file_get_contents to send the data. Note that you will need to have allow_url_fopen enabled in php.ini for this to work.
 			if ( $this->options->get( 'DiscordSendMethod' ) == 'file_get_contents' ) {
-				$this->sendHttpRequest( $webhook ?? $this->options->get( 'DiscordIncomingWebhookUrl' ), $post );
+				$this->sendHttpRequest( $webhook ?: $this->options->get( 'DiscordIncomingWebhookUrl' ), $post );
 
 				if ( !$webhook && $this->options->get( 'DiscordAdditionalIncomingWebhookUrls' ) && is_array( $this->options->get( 'DiscordAdditionalIncomingWebhookUrls' ) ) ) {
 					for ( $i = 0; $i < count( $this->options->get( 'DiscordAdditionalIncomingWebhookUrls' ) ); ++$i ) {
@@ -174,7 +174,7 @@ class DiscordNotifier {
 				}
 			} else {
 				// Call the Discord API through cURL (default way). Note that you will need to have cURL enabled for this to work.
-				$this->sendCurlRequest( $webhook ?? $this->options->get( 'DiscordIncomingWebhookUrl' ), $post );
+				$this->sendCurlRequest( $webhook ?: $this->options->get( 'DiscordIncomingWebhookUrl' ), $post );
 
 				if ( !$webhook && $this->options->get( 'DiscordAdditionalIncomingWebhookUrls' ) && is_array( $this->options->get( 'DiscordAdditionalIncomingWebhookUrls' ) ) ) {
 					for ( $i = 0; $i < count( $this->options->get( 'DiscordAdditionalIncomingWebhookUrls' ) ); ++$i ) {

--- a/includes/DiscordNotifier.php
+++ b/includes/DiscordNotifier.php
@@ -190,6 +190,8 @@ class DiscordNotifier {
 	 * @param string $postData
 	 */
 	private function sendCurlRequest( string $url, string $postData ) {
+		$user_agent = 'DiscordNotifications/3.0 (github.com/Universal-Omega)';
+
 		$h = curl_init();
 		curl_setopt( $h, CURLOPT_URL, $url );
 
@@ -197,8 +199,10 @@ class DiscordNotifier {
 			curl_setopt( $h, CURLOPT_PROXY, $this->options->get( 'DiscordCurlProxy' ) );
 		}
 
-		curl_setopt( $h, CURLOPT_POST, 1 );
+		curl_setopt( $h, CURLOPT_POST, true );
 		curl_setopt( $h, CURLOPT_POSTFIELDS, $postData );
+		curl_setopt( $h, CURLOPT_FOLLOWLOCATION, true );
+		curl_setopt( $h, CURLOPT_HEADER, false );
 		curl_setopt( $h, CURLOPT_RETURNTRANSFER, true );
 
 		// Set 10 second timeout to connection
@@ -207,14 +211,15 @@ class DiscordNotifier {
 		// Set global 10 second timeout to handle all data
 		curl_setopt( $h, CURLOPT_TIMEOUT, 10 );
 
+		curl_setopt( $h, CURLOPT_USERAGENT, $user_agent );
+
 		// Set Content-Type to application/json
 		curl_setopt( $h, CURLOPT_HTTPHEADER, [
-			'Content-Type: application/json',
-			'Content-Length: ' . strlen( $postData )
+			'Content-Type: application/json'
 		] );
 
 		// Execute the curl script
-		$curl_output = curl_exec( $h );
+		curl_exec( $h );
 
 		curl_close( $h );
 	}

--- a/includes/DiscordNotifier.php
+++ b/includes/DiscordNotifier.php
@@ -219,7 +219,7 @@ class DiscordNotifier {
 		] );
 
 		// Execute the curl script
-		curl_exec( $h );
+		$curl_output = curl_exec( $h );
 
 		curl_close( $h );
 	}


### PR DESCRIPTION
Fixes an issue where sometimes messages will not send properly to both the experimental CVT feed and main webhook, sometimes some sent to only the experimental webhook, sometimes only the main one, and sometimes where it sent twice to the experimental webhook and never to any of the other webhooks.