### PR TITLE
Add configuration variables to exclude bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ By default notifications from all users will be sent to your Discord room. If yo
 ```php
 // If this is set, actions by users with this permission won't cause alerts
 $wgDiscordExcludedPermission = '';
+
+// If this is enabled, bots will be excluded from all feeds
+$wgDiscordExcludeBots = false;
 ```
 
 ### Disable notifications from certain pages/namespaces
@@ -222,6 +225,7 @@ You can use the below configuration options to configure it.
 | `$wgDiscordExperimentalCVTMatchFilter`     | []    | An array of regexes to find matches, for sending to the experimental CVT feed. |
 | `$wgDiscordExperimentalCVTSendAllIPEdits`  | true  | Sends all edits by IP users to the experimental CVT feed. |
 | `$wgDiscordExperimentalCVTSendAllNewUsers` | true  | Sends all new user account creations (not autocreations) to the experimental CVT feed. |
+| `$wgDiscordExpermentalCVTExcludeBots`      | true  | Whether or not to exclude bots from the experimental CVT feed. |
 | `$wgDiscordExperimentalFeedLanguageCode`   | ''    | The language code to force the experimental CVT feed localisation too. If an empty string, it will use the default content language of the wiki the notification is from. |
 | `$wgDiscordExperimentalWebhook`            | ''    | The Discord incoming webhook URL to use for the experimental CVT feed. If an empty string, the experimental CVT feed features will be disabled. |
 | `$wgDiscordExperimentalNewUsersWebhook`    | ''    | The Discord incoming webhook URL to use for an experimental new users feed (not including autocreations). If this is set, they will be sent here rather than the experimental CVT feed. |

--- a/extension.json
+++ b/extension.json
@@ -29,6 +29,7 @@
 				"DiscordNotifier",
 				"RevisionLookup",
 				"TitleFactory",
+				"UserFactory",
 				"UserGroupManager",
 				"WikiPageFactory"
 			]

--- a/extension.json
+++ b/extension.json
@@ -97,7 +97,7 @@
 		"DiscordExcludedPermission": {
 			"value": ""
 		},
-		"DiscordNotificationExcludeBots": {
+		"DiscordExcludeBots": {
 			"value": false
 		},
 		"DiscordNotificationWikiUrl": {

--- a/extension.json
+++ b/extension.json
@@ -97,6 +97,9 @@
 		"DiscordExcludedPermission": {
 			"value": ""
 		},
+		"DiscordNotificationExcludeBots": {
+			"value": false
+		},
 		"DiscordNotificationWikiUrl": {
 			"value": ""
 		},
@@ -203,6 +206,9 @@
 			"value": true
 		},
 		"DiscordExperimentalCVTSendAllNewUsers": {
+			"value": true
+		},
+		"DiscordExpermentalCVTExcludeBots": {
 			"value": true
 		},
 		"DiscordExperimentalFeedLanguageCode": {

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -101,7 +101,7 @@ class Hooks implements
 			return;
 		}
 
-		if ( $this->config->get( 'DiscordNotificationExcludeBots' ) && $user->isBot() ) {
+		if ( $this->config->get( 'DiscordExcludeBots' ) && $user->isBot() ) {
 			return;
 		}
 

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -101,6 +101,10 @@ class Hooks implements
 			return;
 		}
 
+		if ( $this->config->get( 'DiscordNotificationExcludeBots' ) && $user->isBot() ) {
+			return;
+		}
+
 		if ( $this->discordNotifier->titleIsExcluded( $wikiPage->getTitle()->getText() ) ) {
 			return;
 		}
@@ -122,8 +126,10 @@ class Hooks implements
 				$content = strip_tags( $content->serialize() );
 			}
 
-			$shouldSendToCVTFeed = $this->config->get( 'DiscordExperimentalCVTSendAllIPEdits' ) &&
-				( !$user->isRegistered() && IPUtils::isIPAddress( $user->getName() ) );
+			if ( $this->config->get( 'DiscordExpermentalCVTExcludeBots' ) && $user->isBot() ) {
+				$shouldSendToCVTFeed = $this->config->get( 'DiscordExperimentalCVTSendAllIPEdits' ) &&
+					( !$user->isRegistered() && IPUtils::isIPAddress( $user->getName() ) );
+			}
 
 			$experimentalLanguageCode = $this->config->get( 'DiscordExperimentalFeedLanguageCode' );
 		}

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -131,7 +131,7 @@ class Hooks implements
 			// and the user is not registered and their name is a valid IP address.
 			// Also, checks if the configuration option to exclude bots from the experimental CVT feed is enabled,
 			// and if it is, skip sending to the experimental CVT feed if the user is a bot.
-			$shouldSendToCVTFeed = $this->config->get('DiscordExperimentalCVTSendAllIPEdits') &&
+			$shouldSendToCVTFeed = $this->config->get( 'DiscordExperimentalCVTSendAllIPEdits' ) &&
 				( !$user->isRegistered() && IPUtils::isIPAddress( $user->getName() ) ) &&
 				!( $this->config->get( 'DiscordExpermentalCVTExcludeBots' ) && $user->isBot() );
 

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -25,6 +25,7 @@ use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRecord;
 use MediaWiki\Storage\Hook\PageSaveCompleteHook;
 use MediaWiki\User\Hook\UserGroupsChangedHook;
+use MediaWiki\User\UserFactory;
 use MediaWiki\User\UserGroupManager;
 use MediaWiki\User\UserIdentityValue;
 use RequestContext;
@@ -56,6 +57,9 @@ class Hooks implements
 	/** @var TitleFactory */
 	private $titleFactory;
 
+	/** @var UserFactory */
+	private $userFactory;
+
 	/** @var UserGroupManager */
 	private $userGroupManager;
 
@@ -67,6 +71,7 @@ class Hooks implements
 	 * @param DiscordNotifier $discordNotifier
 	 * @param RevisionLookup $revisionLookup
 	 * @param TitleFactory $titleFactory
+	 * @param UserFactory $userFactory
 	 * @param UserGroupManager $userGroupManager
 	 * @param WikiPageFactory $wikiPageFactory
 	 */
@@ -75,6 +80,7 @@ class Hooks implements
 		DiscordNotifier $discordNotifier,
 		RevisionLookup $revisionLookup,
 		TitleFactory $titleFactory,
+		UserFactory $userFactory,
 		UserGroupManager $userGroupManager,
 		WikiPageFactory $wikiPageFactory
 	) {
@@ -83,6 +89,7 @@ class Hooks implements
 		$this->discordNotifier = $discordNotifier;
 		$this->revisionLookup = $revisionLookup;
 		$this->titleFactory = $titleFactory;
+		$this->userFactory = $userFactory;
 		$this->userGroupManager = $userGroupManager;
 		$this->wikiPageFactory = $wikiPageFactory;
 	}
@@ -101,7 +108,8 @@ class Hooks implements
 			return;
 		}
 
-		if ( $this->config->get( 'DiscordExcludeBots' ) && $user->isBot() ) {
+		$isBot = $this->userFactory->newFromUserIdentity( $user )->isBot();
+		if ( $this->config->get( 'DiscordExcludeBots' ) && $isBot ) {
 			return;
 		}
 
@@ -133,7 +141,7 @@ class Hooks implements
 			// and if it is, skip sending to the experimental CVT feed if the user is a bot.
 			$shouldSendToCVTFeed = $this->config->get( 'DiscordExperimentalCVTSendAllIPEdits' ) &&
 				( !$user->isRegistered() && IPUtils::isIPAddress( $user->getName() ) ) &&
-				!( $this->config->get( 'DiscordExpermentalCVTExcludeBots' ) && $user->isBot() );
+				!( $this->config->get( 'DiscordExpermentalCVTExcludeBots' ) && $isBot );
 
 			$experimentalLanguageCode = $this->config->get( 'DiscordExperimentalFeedLanguageCode' );
 		}

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -126,10 +126,14 @@ class Hooks implements
 				$content = strip_tags( $content->serialize() );
 			}
 
-			if ( $this->config->get( 'DiscordExpermentalCVTExcludeBots' ) && $user->isBot() ) {
-				$shouldSendToCVTFeed = $this->config->get( 'DiscordExperimentalCVTSendAllIPEdits' ) &&
-					( !$user->isRegistered() && IPUtils::isIPAddress( $user->getName() ) );
-			}
+			// Determine whether to send a message to the experimental CVT feed for the given user edit.
+			// Checks if the configuration option to send all IP edits to the experimental CVT feed is enabled
+			// and the user is not registered and their name is a valid IP address.
+			// Also, checks if the configuration option to exclude bots from the experimental CVT feed is enabled,
+			// and if it is, skip sending to the experimental CVT feed if the user is a bot.
+			$shouldSendToCVTFeed = $this->config->get('DiscordExperimentalCVTSendAllIPEdits') &&
+				( !$user->isRegistered() && IPUtils::isIPAddress( $user->getName() ) ) &&
+				!( $this->config->get( 'DiscordExpermentalCVTExcludeBots' ) && $user->isBot() );
 
 			$experimentalLanguageCode = $this->config->get( 'DiscordExperimentalFeedLanguageCode' );
 		}


### PR DESCRIPTION
Adds configuration to exclude bots, both for the experimental CVT feed and all feeds.

Fixes #54