### PR TITLE
Support sending user blocks to additional feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,16 +221,18 @@ You can use the below configuration options to configure it.
 
 | Configuration | Default | Description |
 |---------------|---------|-------------|
-| `$wgDiscordEnableExperimentalCVTFeatures`  | false | Set to true or none of the experimental CVT features will be enabled. |
-| `$wgDiscordExperimentalCVTMatchLimit`      | 250   | Configure the number of characters to display before and after the found match in the experimental CVT feed. |
-| `$wgDiscordExperimentalCVTMatchFilter`     | []    | An array of regexes to find matches, for sending to the experimental CVT feed. |
-| `$wgDiscordExperimentalCVTSendAllIPEdits`  | true  | Sends all edits by IP users to the experimental CVT feed. |
-| `$wgDiscordExperimentalCVTSendAllNewUsers` | true  | Sends all new user account creations (not autocreations) to the experimental CVT feed. |
-| `$wgDiscordExpermentalCVTExcludeBots`      | true  | Whether or not to exclude bots from the experimental CVT feed. |
-| `$wgDiscordExperimentalFeedLanguageCode`   | ''    | The language code to force the experimental CVT feed localisation too. If an empty string, it will use the default content language of the wiki the notification is from. |
-| `$wgDiscordExperimentalWebhook`            | ''    | The Discord incoming webhook URL to use for the experimental CVT feed. If an empty string, the experimental CVT feed features will be disabled. |
-| `$wgDiscordExperimentalNewUsersWebhook`    | ''    | The Discord incoming webhook URL to use for an experimental new users feed (not including autocreations). If this is set, they will be sent here rather than the experimental CVT feed. |
-| `$wgDiscordNotificationCentralAuthWikiUrl` | ''    | The URL for the wiki to use in the CentralAuth URL. The CentralAuth URL will only appear in the experimental CVT feed. If set to an empty string, no CentralAuth link will appear. |
+| `$wgDiscordEnableExperimentalCVTFeatures`    | false | Set to true or none of the experimental CVT features will be enabled. |
+| `$wgDiscordExperimentalCVTMatchLimit`        | 250   | Configure the number of characters to display before and after the found match in the experimental CVT feed. |
+| `$wgDiscordExperimentalCVTMatchFilter`       | []    | An array of regexes to find matches, for sending to the experimental CVT feed. |
+| `$wgDiscordExperimentalCVTSendAllIPEdits`    | true  | Sends all edits by IP users to the experimental CVT feed. |
+| `$wgDiscordExperimentalCVTSendAllNewUsers`   | true  | Sends all new user account creations (not autocreations) to the experimental CVT feed. |
+| `$wgDiscordExperimentalCVTSendAllUserBlocks` | true  | Sends all user blocks to the experimental CVT feed. |
+| `$wgDiscordExpermentalCVTExcludeBots`        | true  | Whether or not to exclude bots from the experimental CVT feed. |
+| `$wgDiscordExperimentalFeedLanguageCode`     | ''    | The language code to force the experimental CVT feed localisation too. If an empty string, it will use the default content language of the wiki the notification is from. |
+| `$wgDiscordExperimentalWebhook`              | ''    | The Discord incoming webhook URL to use for the experimental CVT feed. If an empty string, the experimental CVT feed features will be disabled. |
+| `$wgDiscordExperimentalNewUsersWebhook`      | ''    | The Discord incoming webhook URL to use for an experimental new users feed (not including autocreations). If this is set, they will be sent here rather than the experimental CVT feed. |
+| `$wgDiscordExperimentalUserBlocksWebhook`    | ''    | The Discord incoming webhook URL to use for an experimental user blocks feed. If this is set, they will be sent here rather than the experimental CVT feed. |
+| `$wgDiscordNotificationCentralAuthWikiUrl`   | ''    | The URL for the wiki to use in the CentralAuth URL. The CentralAuth URL will only appear in the experimental CVT feed. If set to an empty string, no CentralAuth link will appear. |
 
 ## License
 

--- a/extension.json
+++ b/extension.json
@@ -209,6 +209,9 @@
 		"DiscordExperimentalCVTSendAllNewUsers": {
 			"value": true
 		},
+		"DiscordExperimentalCVTSendAllUserBlocks": {
+			"value": true
+		},
 		"DiscordExpermentalCVTExcludeBots": {
 			"value": true
 		},
@@ -219,6 +222,9 @@
 			"value": ""
 		},
 		"DiscordExperimentalNewUsersWebhook": {
+			"value": ""
+		},
+		"DiscordExperimentalUserBlocksWebhook": {
 			"value": ""
 		}
 	},

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -488,7 +488,7 @@ class Hooks implements
 					$this->discordNotifier->getDiscordUserText( $user, $experimentalLanguageCode ),
 					$this->discordNotifier->getDiscordUserText(
 						$block->getTargetUserIdentity() ?? UserIdentityValue::newAnonymous( $block->getTargetName() ),
-						$experimentalLanguageCode
+						$experimentalLanguageCode, true
 					),
 					$reason == '' ? '' : $this->discordNotifier->getMessageInLanguage( 'discordnotifications-block-user-reason', $experimentalLanguageCode ) . " '" . $reason . "'.",
 					$block->getExpiry(),

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -475,6 +475,30 @@ class Hooks implements
 			'<' . $this->discordNotifier->parseurl( $this->config->get( 'DiscordNotificationWikiUrl' ) . $this->config->get( 'DiscordNotificationWikiUrlEnding' ) . $this->config->get( 'DiscordNotificationWikiUrlEndingBlockList' ) ) . '|' . $this->discordNotifier->getMessage( 'discordnotifications-block-user-list' ) . '>.'
 		);
 
+		$webhook = $this->config->get( 'DiscordEnableExperimentalCVTFeatures' ) &&
+			$this->config->get( 'DiscordExperimentalCVTSendAllUserBlocks' ) ?
+			$this->config->get( 'DiscordExperimentalWebhook' ) :
+			( $this->config->get( 'DiscordExperimentalUserBlocksWebhook' ) ?: null );
+
+		if ( $webhook ) {
+			$experimentalLanguageCode = $this->config->get( 'DiscordExperimentalFeedLanguageCode' );
+			if ( $experimentalLanguageCode ) {
+				$messageInLanguage = $this->discordNotifier->getMessageInLanguage( 'discordnotifications-block-user',
+					$experimentalLanguageCode,
+					$this->discordNotifier->getDiscordUserText( $user, $experimentalLanguageCode ),
+					$this->discordNotifier->getDiscordUserText(
+						$block->getTargetUserIdentity() ?? UserIdentityValue::newAnonymous( $block->getTargetName() ),
+						$experimentalLanguageCode
+					),
+					$reason == '' ? '' : $this->discordNotifier->getMessageInLanguage( 'discordnotifications-block-user-reason', $experimentalLanguageCode ) . " '" . $reason . "'.",
+					$block->getExpiry(),
+					'<' . $this->discordNotifier->parseurl( $this->config->get( 'DiscordNotificationWikiUrl' ) . $this->config->get( 'DiscordNotificationWikiUrlEnding' ) . $this->config->get( 'DiscordNotificationWikiUrlEndingBlockList' ) ) . '|' . $this->discordNotifier->getMessageInLanguage( 'discordnotifications-block-user-list', $experimentalLanguageCode ) . '>.'
+				);
+			}
+
+			$this->discordNotifier->notify( $messageInLanguage ?? $message, $user, 'user_blocked', [], $webhook );
+		}
+
 		$this->discordNotifier->notify( $message, $user, 'user_blocked' );
 	}
 


### PR DESCRIPTION
Supports either a unique feed or the expermental CVT feed.

Fixes #60 