### PR TITLE
encode ? to %3F in url

### DIFF
--- a/includes/DiscordNotifier.php
+++ b/includes/DiscordNotifier.php
@@ -236,6 +236,7 @@ class DiscordNotifier {
 		$url = str_replace( ' ', '_', $url );
 		$url = str_replace( '(', '%28', $url );
 		$url = str_replace( ')', '%29', $url );
+		$url = str_replace( '?', '%3F', $url );
 
 		return $url;
 	}


### PR DESCRIPTION
Bot output was linking to https://meta.miraheze.org/wiki/User:Rob_Kam/Draft:My_wiki_has_been_approved_—_what_do_I_do_now instead of https://meta.miraheze.org/wiki/User:Rob_Kam/Draft:My_wiki_has_been_approved_—_what_do_I_do_now?

I assume the trailing ? gets cut off by discord so encode it to %3F and see if that works. Untested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced URL encoding for Discord notifications to ensure smoother and more reliable integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->